### PR TITLE
#7 공통 코드 포맷 지정

### DIFF
--- a/buildScripts/configuration/codestyle_intellij.xml
+++ b/buildScripts/configuration/codestyle_intellij.xml
@@ -1,0 +1,33 @@
+<code_scheme name="f-lab coding style" version="173">
+  <option name="FORMATTER_TAGS_ENABLED" value="true" />
+  <JetCodeStyleSettings>
+    <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+  </JetCodeStyleSettings>
+  <TypeScriptCodeStyleSettings version="0">
+    <option name="FORCE_SEMICOLON_STYLE" value="true" />
+    <option name="REFORMAT_C_STYLE_COMMENTS" value="true" />
+    <option name="USE_PUBLIC_MODIFIER" value="true" />
+    <option name="PREFER_AS_TYPE_CAST" value="true" />
+    <option name="USE_DOUBLE_QUOTES" value="false" />
+    <option name="FORCE_QUOTE_STYlE" value="true" />
+    <option name="PREFER_EXPLICIT_TYPES_VARS_FIELDS" value="true" />
+    <option name="PREFER_EXPLICIT_TYPES_FUNCTION_RETURNS" value="true" />
+    <option name="PREFER_EXPLICIT_TYPES_FUNCTION_EXPRESSION_RETURNS" value="true" />
+    <option name="ENFORCE_TRAILING_COMMA" value="WhenMultiline" />
+    <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+    <option name="SPACES_WITHIN_IMPORTS" value="true" />
+    <option name="IMPORT_SORT_MODULE_NAME" value="true" />
+  </TypeScriptCodeStyleSettings>
+  <codeStyleSettings language="TypeScript">
+    <option name="WRAP_COMMENTS" value="true" />
+    <option name="WRAP_ON_TYPING" value="0" />
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="2" />
+      <option name="TAB_SIZE" value="2" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="kotlin">
+    <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+  </codeStyleSettings>
+</code_scheme>


### PR DESCRIPTION
IntelliJ 편집 화면에서 File -> Settings 화면 진입 후,

좌측 편집창의 Editor > Code style 선택한 다음,

Scheme 선택창 우측의 톱니바퀴 클릭, 

Import scheme > IntelliJ Code style XML 선택 후 이 파일 적용하면 됩니다.