### PR TITLE
 파일 끝에 newline추가하는 .editorconfig 파일 추가 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+insert_final_newline = true


### PR DESCRIPTION
### 개요
코드 포맷 설정을 모든 작업자에게 일괄 적용할 수 있는 .editorconfig을 추가

### AS-IS
파일 끝에 newline을 추가하는 옵션의 경우 codestyle.xml에서 적용 불가능

### TO-BE
newline추가 옵션은 setting->editor->general항목에 있어 codestyle.xml로는 설정할 수 없습니다.
대신 .editorconfig을 사용하여 오버라이드가 가능하여 .editorconfig파일을 추가했습니다
이후에도 codestyle에서 적용 불가능한 옵션이 존재하는 경우 .editorconfig에 적용
closes #7 