### PR TITLE
#8 Detekt 환경 설정 수정

### DIFF
--- a/buildScripts/detekt.gradle
+++ b/buildScripts/detekt.gradle
@@ -1,8 +1,18 @@
-apply plugin: 'io.gitlab.arturbosch.detekt'
+apply plugin: "io.gitlab.arturbosch.detekt"
+apply from: "$project.rootDir/buildScripts/packaging.gradle"
 
 detekt {
+    def buildConfig = getBuildConfig()
+
     toolVersion = "$version_detekt"
     config = files("$project.rootDir/buildScripts/settings/detekt-config.yml")
+    input = files(
+            "src/main/java",
+            "src/main/kotlin",
+            "src/$buildConfig/java",
+            "src/$buildConfig/kotlin"
+    )
+
     reports {
         xml {
             enabled = true

--- a/buildScripts/kotlin.gradle
+++ b/buildScripts/kotlin.gradle
@@ -1,6 +1,4 @@
 apply plugin: "kotlin"
-apply plugin: "io.gitlab.arturbosch.detekt"
-apply from: "$project.rootDir/buildScripts/packaging.gradle"
 
 compileKotlin {
     kotlinOptions.jvmTarget = "$version_target_jvm"
@@ -15,25 +13,4 @@ dependencies {
     implementation "com.github.javafaker:javafaker:1.0.2"
     testImplementation "org.mockito:mockito-core:3.+"
     testImplementation 'org.hamcrest:hamcrest:2.2'
-}
-
-detekt {
-
-    def buildConfig = getBuildConfig()
-
-    // Version of Detekt that will be used. When unspecified the latest detekt
-    // version found will be used. Override to stay on the same version.
-    toolVersion = "$version_detekt"
-
-    // The directories where detekt looks for source files.
-    // Defaults to `files("src/main/java", "src/main/kotlin")`.
-    input = files(
-            "src/main/java",
-            "src/main/kotlin",
-            "src/$buildConfig/java",
-            "src/$buildConfig/kotlin"
-    )
-
-    autoCorrect = true
-
 }


### PR DESCRIPTION
### 개요
Detekt 환경 설정 수정

### AS-IS
현재 두개 Gradle 파일에 detekt 설정이 각각 나뉘어져 있음

### TO-BE
두개 파일로 나뉘어져 있던 Detekt 환경설정을 하나로 합치고, 자동 수정 기능을 Off 함.
이로 인해 설정을 한 곳에서 관리할 수 있어 편리해진다.

자동 수정 Off 한 이유는 문제 직접 눈으로 확인하고 수정하기 위함입니다.
