### PR TITLE
#8 테스트 그룹화

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,6 +22,15 @@ Spring framework 를 이용한 다중 접속 애플리케이션에서 발생하�
 
 최대한 효율적으로 TDD 를 연습하기 위해 link:{link-todo-sheets}[할 일 목록 Google sheets] 와 link:{link-todo-issues}[Issue Kanban board] 를 적극 활용하고 있습니다.
 
+[[running-tests]]
+=== 테스트 실행
+이 프로젝트에서는 Unit / Integration / End to end 테스트들을 종류별로 구분해 구현하고 있습니다. 테스트들은 martinFowler.com 의 link:https://martinfowler.com/articles/practical-test-pyramid.html[The practical test pyramid] 라는 글에 따라 규모별로 구분하고 있으모, 각 테스트를 실행하는 gradle task 명은 아래와 같습니다.
+
+* `test` - 등록된 모든 테스트를 실행합니다. 시간이 가장 많이 걸립니다.
+* `unitTest` - Unit test 들만을 모두 실행합니다. 시간이 가장 적게 걸립니다.
+* `integrationTest` - Integration test 들만을 모두 실행합니다. Unit test 보다는 실행 시간이 좀 더 걸립니다.
+* `e2eTest` - End to end test 들만을 모두 실행합니다. End to end test 를 일컫는 말들은 여러 가지가 있지만 이 프로젝트에서는 API 가 정상 동작하는지를 확인하는 테스트를 의미합니다.
+
 [[code-quality-measurement]]
 === 코드 품질 측정
 
@@ -33,11 +42,11 @@ Spring framework 를 이용한 다중 접속 애플리케이션에서 발생하�
 
 [source,shell script]
 ----
-./gradlew detekt test jacocoTestReport
+./gradlew detekt testAll jacocoTestReport
 ----
 
 각 Task 들의 설명은 다음과 같습니다.
 
 - `detekt`: link:{link-detekt}[detekt] 를 실행. Kotlin 정적 분석 실행.
-- `test`: 개별 모듈 내에 작성한 test 들을 실행.
+- `test`: 개별 모듈 내에 작성한 test 들을 모두 실행.
 - `jacocoTestReport`: 테스트 실행 및 테스트의 코드 커버리지 측정.

--- a/app-core/src/test/kotlin/kr/flab/wiki/core/login/PostServiceTest.kt
+++ b/app-core/src/test/kotlin/kr/flab/wiki/core/login/PostServiceTest.kt
@@ -1,30 +1,27 @@
 package kr.flab.wiki.core.login
 
+import kr.flab.wiki.TAG_TEST_UNIT
 import kr.flab.wiki.core.post.business.PostService
 import kr.flab.wiki.core.post.business.PostServiceImpl
 import kr.flab.wiki.core.post.exception.PostValidationException
 import kr.flab.wiki.core.post.persistence.Post
-import kr.flab.wiki.core.post.persistence.PostEntity
 import kr.flab.wiki.core.post.persistence.User
 import kr.flab.wiki.core.post.repository.PostRepository
 import kr.flab.wiki.core.post.repository.PostRepositoryImpl
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.lessThan
 import org.hamcrest.Matchers.lessThanOrEqualTo
 import org.hamcrest.core.Is.`is`
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.mockito.Mockito.*
-import java.time.LocalDateTime
 
-//한글 사용을 위해 추가
-@Suppress("NonAsciiCharacters")
-@DisplayName("해당 테스트는 PostService 메서드를 테스트하는 클래스이다.")
+@Tag(TAG_TEST_UNIT)
+@Suppress("ClassName", "NonAsciiCharacters") // 테스트 표현을 위한 한글 사용
+@DisplayName("PostService 의 동작 시나리오를 확인한다.")
 class PostServiceTest {
-
-    lateinit var mockPostRepository: PostRepository
-    lateinit var sut: PostService
+    private lateinit var mockPostRepository: PostRepository
+    private lateinit var sut: PostService
 
     @BeforeEach
     private fun setup() {
@@ -33,98 +30,85 @@ class PostServiceTest {
     }
 
     @Nested
-    @DisplayName("임의의 사용자가")
     inner class `임의의 사용자가` {
-
-        //given
+        // given:
         private val user: User = createRandomPostUserEntity()
 
         @Nested
-        @DisplayName("제목이 100자 이상인 포스트를 등록하는 경우")
         inner class `제목이 100자 이상인 포스트를 등록하는 경우` {
-
-            //given
+            // given:
             private val post: Post = createRandomPostEntity(user, title = "a".repeat(120))
 
             @BeforeEach
-            fun mocking() {
+            fun setupWhen() {
                 `when`(mockPostRepository.save(post)).thenReturn(post)
             }
 
             @Test
-            @DisplayName("Exception이 발생한다")
-            fun `Exception이 발생한다`() {
-                //when
+            fun `Exception 이 발생한다`() {
+                // then:
                 val exception: PostValidationException =
                     assertThrows(PostValidationException::class.java) { sut.writePost(post) }
-                //then
-                assertThat(exception.message, `is`("제목은 100자 미만이어야 합니다."))
 
+                // expect:
+                assertThat(exception.message, `is`("제목은 100자 미만이어야 합니다."))
             }
         }
 
         @Nested
-        @DisplayName("본문이 10,000자 이상인 포스트를 등록하는 경우")
         inner class `본문이 10,000자 이상인 포스트를 등록하는 경우` {
-
-            //given
+            // given:
             private val post: Post = createRandomPostEntity(user, text = "abcdefghij".repeat(1000))
 
             @BeforeEach
-            fun mocking() {
+            fun setupWhen() {
                 `when`(mockPostRepository.save(post)).thenReturn(post)
             }
 
             @Test
-            @DisplayName("Exception이 발생한다")
-            fun `Exception이 발생한다`() {
-                //when
+            fun `Exception 이 발생한다`() {
+                // then:
                 val exception: PostValidationException =
                     assertThrows(PostValidationException::class.java) { sut.writePost(post) }
-                //then
+
+                // expect:
                 assertThat(exception.message, `is`("내용은 10,000자 미만이어야 합니다."))
             }
         }
 
         @Nested
-        @DisplayName("중복된 제목으로 포스트를 등록하는 경우")
         inner class `중복된 제목으로 포스트를 등록하는 경우` {
-
-            //given
+            // given:
             private val postWithDuplicateTitleFirst = createRandomPostEntity(user, title = "duplicateTitle")
             private val postWithDuplicateTitleSecond = createRandomPostEntity(user, title = "duplicateTitle")
 
             @BeforeEach
-            fun mocking() {
+            fun setupWhen() {
                 `when`(mockPostRepository.save(postWithDuplicateTitleFirst)).thenReturn(postWithDuplicateTitleFirst)
             }
 
             @Test
-            @DisplayName("Exception이 발생한다")
-            fun `Exception이 발생한다`() {
-                //when
-                //첫번째 생성
-                val firstWrittenPost = sut.writePost(postWithDuplicateTitleFirst)
-                //생성한 경우 isTitleAlreadyExists는 true를 반환하게 된다.
-                if (firstWrittenPost != null) {
-                    `when`(mockPostRepository.isTitleAlreadyExists(postWithDuplicateTitleFirst.title)).thenReturn(true)
-                }
+            fun `Exception 이 발생한다`() {
+                // given: "첫번째 생성"
+                `when`(mockPostRepository.isTitleAlreadyExists(postWithDuplicateTitleFirst.title)).thenReturn(false)
+                sut.writePost(postWithDuplicateTitleFirst)
 
+                // when: "이제 첫번째 글 제목에 대해 '이미 존재함' 을 반환하도록 구성한다"
+                `when`(mockPostRepository.isTitleAlreadyExists(postWithDuplicateTitleFirst.title)).thenReturn(true)
+
+                // then:
                 val exception: PostValidationException =
                     assertThrows(PostValidationException::class.java) { sut.writePost(postWithDuplicateTitleSecond) }
 
-                //then
+                // expect:
                 assertThat(exception.message, `is`("이미 해당 제목으로 생성한 포스트가 존재합니다."))
             }
-
         }
 
         @Nested
-        @DisplayName("전체 Post 목록을 클릭하는 경우")
         inner class `전체 Post 목록을 클릭하는 경우` {
-
             @BeforeEach
-            fun mocking() {
+            fun setupWhen() {
                 `when`(mockPostRepository.getPosts())
                     .thenReturn(
                         mutableListOf(
@@ -135,90 +119,73 @@ class PostServiceTest {
             }
 
             @Test
-            @DisplayName("Post 리스트를 불러온다.")
             fun `Post 리스트를 불러온다`() {
-                //when
+                // then:
                 val posts: List<Post> = sut.getPosts()
 
-                //then
+                // expect:
                 verify(mockPostRepository, times(1)).getPosts()
                 assertThat(posts.size, `is`(2))
-
             }
-
         }
 
         @Nested
         @DisplayName("특정 Post의 제목을 클릭하는 경우")
         inner class `특정 Post의 제목을 클릭하는 경우` {
-
-            //given
+            // given:
             private val post: Post = createRandomPostEntity(user)
 
             @BeforeEach
-            fun mocking() {
+            fun setupWhen() {
                 `when`(mockPostRepository.getPost(post.id))
                     .thenReturn(post)
             }
 
             @Test
-            @DisplayName("해당 Post의 상세정보 혹은 null을 반환한다.")
             fun `해당 Post의 상세정보 혹은 null을 반환한다`() {
-                //when
+                // then:
                 val loadedPost: Post? = sut.getPost(post.id)
 
-                //then
+                // expect:
                 verify(mockPostRepository, times(1)).getPost(post.id)
                 assertThat(loadedPost?.text, `is`(post.text))
             }
         }
 
         @Nested
-        @DisplayName("특정 Post의 내용을 수정하는 경우")
         inner class `특정 Post의 내용을 수정하는 경우` {
-
-            //given
+            // given:
             private val post: Post = createRandomPostEntity(user)
-
-            //given
             private val randomEditedPost: Post = createRandomEditedPostEntity(user, post)
 
             @BeforeEach
-            fun mocking() {
+            fun setupWhen() {
                 `when`(mockPostRepository.getPost(post.id))
                     .thenReturn(post)
                 `when`(mockPostRepository.editPost(randomEditedPost)).thenReturn(randomEditedPost)
             }
 
             @Test
-            @DisplayName("해당 Post의 내용이 변경된다.")
             fun `해당 Post의 내용이 변경된다`() {
-
-                //when
+                // then:
                 val editedPost: Post? = sut.editPost(randomEditedPost)
 
-                //then
+                // expect:
                 verify(mockPostRepository, times(1)).editPost(randomEditedPost)
                 assertThat(post.text, `is`(not(randomEditedPost.text)))
                 assertThat(randomEditedPost.text, `is`(editedPost!!.text))
-
             }
 
             @Test
-            @DisplayName("해당 Post의 version이 증가한다.")
             fun `해당 Post의 version이 증가한다`() {
-
-                //when
+                // then:
                 val editedPost: Post? = sut.editPost(randomEditedPost)
 
-                //then
+                // expect:
                 verify(mockPostRepository, times(1)).editPost(randomEditedPost)
                 assertThat(post.version, `is`(lessThanOrEqualTo(editedPost!!.version)))
                 assertThat(randomEditedPost.version, `is`(lessThanOrEqualTo(editedPost!!.version)))
-
             }
-
         }
-
     }
 }

--- a/app-core/src/test/kotlin/kr/flab/wiki/core/login/UserLoginServiceTest.kt
+++ b/app-core/src/test/kotlin/kr/flab/wiki/core/login/UserLoginServiceTest.kt
@@ -1,5 +1,6 @@
 package kr.flab.wiki.core.login
 
+import kr.flab.wiki.TAG_TEST_UNIT
 import kr.flab.wiki.core.login.business.UserLoginService
 import kr.flab.wiki.core.login.business.UserLoginServiceImpl
 import kr.flab.wiki.core.login.exception.UserValidationException
@@ -10,35 +11,29 @@ import kr.flab.wiki.core.login.repository.UserLoginRepository
 import kr.flab.wiki.core.login.repository.UserLoginRepositoryImpl
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.Is.`is`
+import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
 
-@DisplayName("해당 테스트는 UserLoginService 메서드를 테스트하는 클래스이다.")
+@Tag(TAG_TEST_UNIT)
+@DisplayName("UserLoginService 의 동작 시나리오를 확인한다.")
 class UserLoginServiceTest {
-
-    lateinit var mockUserLoginRepository : UserLoginRepository
-    lateinit var mockSessionRepository : SessionRepository
-    lateinit var sut : UserLoginService
+    private lateinit var mockUserLoginRepository: UserLoginRepository
+    private lateinit var mockSessionRepository: SessionRepository
+    private lateinit var sut: UserLoginService
 
     @BeforeEach
     private fun setup() {
-
         mockUserLoginRepository = mock(UserLoginRepositoryImpl::class.java)
         mockSessionRepository = mock(SessionRepositoryImpl::class.java)
         sut = UserLoginServiceImpl(mockUserLoginRepository, mockSessionRepository)
-
     }
 
     @Nested
     @DisplayName("로그인 하지 않은 사용자는")
     inner class GivenAnonymousUser {
-
         // given
-        private val user : User = createRandomUserEntity()
+        private val user: User = createRandomUserEntity()
 
         @Nested
         @DisplayName("이메일/비밀번호 입력 후 로그인 버튼을 클릭했을 때")
@@ -51,20 +46,22 @@ class UserLoginServiceTest {
                 @Test
                 @DisplayName("세션에 유저 정보를 저장하고 로그인에 성공한다.")
                 fun thenCreateSessionAndLoginSuccess() {
-
-                    // mocking
-                    `when`(mockUserLoginRepository.findUserWithIdAndPassword(user.email, user.password)).thenReturn(user)
+                    // when
+                    `when`(
+                        mockUserLoginRepository.findUserWithIdAndPassword(
+                            user.email,
+                            user.password
+                        )
+                    ).thenReturn(user)
                     `when`(mockSessionRepository.setAttribute("userName", user.email)).thenReturn(user.email)
 
-                    // when
-                    val loggedInUser : User? = sut.login(user)
+                    // then
+                    val loggedInUser: User? = sut.login(user)
 
-                    // expected/then
+                    // expect
                     verify(mockSessionRepository, times(1)).setAttribute("userName", user.email)
                     assertThat(user.email, `is`(loggedInUser?.email))
-
                 }
-
             }
 
             @Nested
@@ -74,24 +71,24 @@ class UserLoginServiceTest {
                 @Test
                 @DisplayName("로그인에 실패한다.")
                 fun thenLoginFailed() {
-
-                    // mocking
-                    `when`(mockUserLoginRepository.findUserWithIdAndPassword(user.email, user.password)).thenReturn(null)
+                    // when
+                    `when`(
+                        mockUserLoginRepository.findUserWithIdAndPassword(
+                            user.email,
+                            user.password
+                        )
+                    ).thenReturn(null)
                     `when`(mockSessionRepository.setAttribute("userName", user.email)).thenReturn(user.email)
 
-                    // when
-                    val loginException : UserValidationException = assertThrows(UserValidationException::class.java) { sut.login(user) }
+                    // then
+                    val loginException: UserValidationException =
+                        assertThrows(UserValidationException::class.java) { sut.login(user) }
 
-                    // expected/then
+                    // expect
                     assertThat(loginException.message, `is`("There's No Matched Member!"))
                     verify(mockSessionRepository, times(0)).setAttribute("userName", user.email)
-
                 }
-
             }
-
         }
-
     }
-
 }

--- a/app-core/src/test/kotlin/kr/flab/wiki/core/post/PostServiceTest.kt
+++ b/app-core/src/test/kotlin/kr/flab/wiki/core/post/PostServiceTest.kt
@@ -1,5 +1,6 @@
 package kr.flab.wiki.core.post
 
+import kr.flab.wiki.TAG_TEST_UNIT
 import kr.flab.wiki.core.domain.PostLengthPolicy
 import kr.flab.wiki.core.domain.PostLengthPolicyImpl
 import kr.flab.wiki.core.domain.PostService
@@ -10,18 +11,17 @@ import kr.flab.wiki.core.domain.user.User
 import kr.flab.wiki.core.util.TestUtils
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.*
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 
-//테스트에서 한글 사용
-@Suppress("NonAsciiCharacters")
+@Tag(TAG_TEST_UNIT)
+@Suppress("NonAsciiCharacters", "ClassName") // 테스트 표현을 위한 한글 사용
+@DisplayName("PostService 의 동작 시나리오를 확인한다.")
 class PostServiceTest {
-    lateinit var mockPostRepository: PostRepository
-    lateinit var mockPostLengthPolicy: PostLengthPolicy
-    lateinit var sut: PostService
+    private lateinit var mockPostRepository: PostRepository
+    private lateinit var mockPostLengthPolicy: PostLengthPolicy
+    private lateinit var sut: PostService
 
     @BeforeEach
     fun setup() {
@@ -32,7 +32,7 @@ class PostServiceTest {
 
     @Nested
     inner class `랜덤 유저가` {
-        lateinit var randomUser: User
+        private lateinit var randomUser: User
 
         @BeforeEach
         fun beforeEach() {
@@ -41,14 +41,12 @@ class PostServiceTest {
 
         @Nested
         inner class `랜덤 항목을` {
-
-            lateinit var randomPost: Post
+            private lateinit var randomPost: Post
 
             @BeforeEach
             fun beforeEach() {
                 randomPost = TestUtils.createRandomPost(user = randomUser)
                 setRepositoryAction(mockPostRepository, randomPost)
-
             }
 
             @Nested
@@ -69,14 +67,12 @@ class PostServiceTest {
 
         @Nested
         inner class `제목없는 항목을` {
-
-            lateinit var randomPost: Post
+            private lateinit var randomPost: Post
 
             @BeforeEach
             fun beforeEach() {
                 randomPost = TestUtils.createRandomPost(user = randomUser, title = "")
                 setRepositoryAction(mockPostRepository, randomPost)
-
             }
 
             @Test
@@ -88,14 +84,12 @@ class PostServiceTest {
 
         @Nested
         inner class `제목이 100자 이상인 항목을` {
-
-            lateinit var randomPost: Post
+            private lateinit var randomPost: Post
 
             @BeforeEach
             fun beforeEach() {
                 randomPost = TestUtils.createRandomPost(user = randomUser, title = "title".repeat(25))
                 setRepositoryAction(mockPostRepository, randomPost)
-
             }
 
             @Test
@@ -106,14 +100,12 @@ class PostServiceTest {
 
         @Nested
         inner class `본문이 10000만 이상인 항목을` {
-
-            lateinit var randomPost: Post
+            private lateinit var randomPost: Post
 
             @BeforeEach
             fun beforeEach() {
                 randomPost = TestUtils.createRandomPost(user = randomUser, mainText = "titletitle".repeat(1000))
                 setRepositoryAction(mockPostRepository, randomPost)
-
             }
 
             @Test

--- a/app-lib/src/test/kotlin/kr/flab/wiki/TestTags.kt
+++ b/app-lib/src/test/kotlin/kr/flab/wiki/TestTags.kt
@@ -1,0 +1,20 @@
+/**
+ * 빌드 스크립트 buildScripts/testing.gradle 에 정의한 테스트 그룹 상수 모음.
+ * 개별 테스트들에 이 파일에 정의한 Tag 들을 반드시 선언해야 테스트를 단계별로 실행할 수 있습니다.
+ */
+package kr.flab.wiki
+
+/**
+ * Unit test 또는 "Small test"
+ */
+const val TAG_TEST_UNIT = "unit"
+
+/**
+ * Integration test 또는 "Medium test"
+ */
+const val TAG_TEST_INTEGRATION = "integration"
+
+/**
+ * End to End test 또는 "Large test"
+ */
+const val TAG_TEST_E2E = "e2e"

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+apply from: "$project.rootDir/buildScripts/test-aggregator.gradle"
+
 buildscript {
     ext {
         // lang

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,9 @@ buildscript {
         version_junit5 = "5.7.1"
         version_detekt = "1.16.0"
         version_jacoco = "0.8.6"
+        version_javafaker = "1.0.2"
+        version_hamcrest = "2.2"
+        version_mockito = "3.8.0"
 
         // Automatic documentation
         version_asciidoctor_gradle = "3.3.2"

--- a/buildScripts/test-aggregator.gradle
+++ b/buildScripts/test-aggregator.gradle
@@ -1,0 +1,122 @@
+import groovy.time.TimeCategory
+import org.gradle.api.internal.tasks.testing.results.DefaultTestResult
+import org.gradle.internal.logging.text.StyledTextOutput.Style
+import org.gradle.internal.logging.text.StyledTextOutputFactory
+
+// Container for tests summaries
+ext.testsResults = []
+
+class TestRecord {
+    final String projectName
+    final String taskName
+    final String reportPath
+    final DefaultTestResult result
+
+    TestRecord(final String projectName,
+               final String taskName,
+               final String reportPath,
+               final DefaultTestResult result
+    ) {
+        this.projectName = projectName
+        this.taskName = taskName
+        this.reportPath = reportPath
+        this.result = result
+    }
+
+    String moduleSummary() {
+        return "${projectName}:${taskName}"
+    }
+
+    String resultSummary() {
+        return "${result.resultType}"
+    }
+
+    String testSummary() {
+        return "${result.testCount} tests, " +
+                "${result.successfulTestCount} successes, " +
+                "${result.failedTestCount} failures, " +
+                "${result.skippedTestCount} skipped"
+    }
+
+    String timeSummary() {
+        return "in ${TimeCategory.minus(new Date(result.endTime), new Date(result.startTime))}"
+    }
+
+    String reportFileSummary() {
+        return "Report file: ${reportPath}"
+    }
+
+    @Override
+    String toString() {
+        return "${moduleSummary()} ${resultSummary()}\n" +
+                "${testSummary()} ${timeSummary()}\n" +
+                "${reportFileSummary()}\n"
+    }
+}
+
+allprojects {
+    tasks.withType(Test) { testTask ->
+        // Always try to run all tests for all modules. Build will fail on printing phase.
+        ignoreFailures = true
+
+        afterSuite { desc, result ->
+            // Only summarize results for whole modules
+            if (desc.parent) {
+                return
+            }
+
+            rootProject.testsResults += new TestRecord(
+                    testTask.project.name,
+                    testTask.name,
+                    testTask.reports.html.entryPoint.absolutePath,
+                    result
+            )
+        }
+    }
+}
+
+gradle.buildFinished {
+    def out = services.get(StyledTextOutputFactory).create("ansi-output")
+
+    def printResult = { maxLength, report ->
+        def styleBuilder = out.style(Style.Normal).text("${report.moduleSummary()} ")
+
+        def resultStyle
+        switch(report.result.resultType) {
+            case TestResult.ResultType.SUCCESS:
+                resultStyle = Style.Success
+                break
+            case TestResult.ResultType.FAILURE:
+                resultStyle = Style.Failure
+                break
+            case TestResult.ResultType.SKIPPED:
+                resultStyle = Style.Info
+                break
+            default:
+                resultStyle = Style.Normal
+        }
+
+        styleBuilder.style(resultStyle).text("${report.resultSummary()}\n")
+                .style(Style.Normal).text("${report.testSummary()} ${report.timeSummary()}\n")
+                .text(report.reportFileSummary())
+                .println()
+        println("${"=" * maxLength}")
+    }
+
+    def allResults = rootProject.ext.testsResults
+    if (!allResults.isEmpty()) {
+        def maxLength = allResults.toListString().readLines().flatten().collect { it.length() }.max()
+        println("${"=" * maxLength}")
+        allResults.forEach {
+            printResult maxLength, it
+        }
+    }
+
+    if (allResults.any { it.result.resultType == TestResult.ResultType.FAILURE }) {
+        throw new GradleException("THERE WERE SOME FAILING TESTS.")
+    }
+
+    if (allResults.any { it.result.resultType == TestResult.ResultType.SKIPPED }) {
+        out.style(Style.Info).println("There were some skipped tests. Please review them.")
+    }
+}

--- a/buildScripts/testing.gradle
+++ b/buildScripts/testing.gradle
@@ -1,18 +1,25 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
+/**
+ * JUnit5 의 Test grouping 기능을 위해 정의.
+ *
+ * https://docs.gradle.org/current/userguide/java_testing.html#test_grouping
+ * https://junit.org/junit5/docs/current/user-guide/#writing-tests-tagging-and-filtering
+ */
+def TAG_UNIT_TEST = "unit"
+def TAG_INTEGRATION_TEST = "integration"
+def TAG_E2E_TEST = "e2e"
+
 dependencies {
     // JUnit5
     testImplementation "org.junit.jupiter:junit-jupiter-api:$version_junit5"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$version_junit5"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$version_junit5"
 
-    // javafaker
-    testImplementation group: 'com.github.javafaker', name: 'javafaker', version: '1.0.2'
-    // Hamcrest
-    testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
-    // https://mvnrepository.com/artifact/org.mockito/mockito-core
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.8.0'
+    testImplementation "com.github.javafaker:javafaker:$version_javafaker"
+    testImplementation "org.hamcrest:hamcrest:$version_hamcrest"
+    testImplementation "org.mockito:mockito-core:$version_mockito"
 }
 
 check.dependsOn test
@@ -32,13 +39,83 @@ artifacts {
 
 test {
     useJUnitPlatform()
+
     reports {
         html.enabled = true
         junitXml.enabled = true
     }
 
     testLogging {
-        events TestLogEvent.SKIPPED, TestLogEvent.FAILED //, TestLogEvent.STANDARD_OUT, TestLogEvent.STANDARD_ERROR
+        events TestLogEvent.SKIPPED, TestLogEvent.FAILED
+
+        exceptionFormat TestExceptionFormat.FULL
+        showExceptions true
+        showCauses true
+        showStackTraces true
+    }
+}
+
+task unitTest(type: Test) {
+    group "verification"
+
+    useJUnitPlatform {
+        includeTags TAG_UNIT_TEST
+        excludeTags "*"
+    }
+
+    reports {
+        html.enabled = true
+        junitXml.enabled = true
+    }
+
+    testLogging {
+        events TestLogEvent.SKIPPED, TestLogEvent.FAILED
+
+        exceptionFormat TestExceptionFormat.FULL
+        showExceptions true
+        showCauses true
+        showStackTraces true
+    }
+}
+
+task integrationTest(type: Test) {
+    group "verification"
+
+    useJUnitPlatform {
+        includeTags TAG_INTEGRATION_TEST
+        excludeTags "*"
+    }
+
+    reports {
+        html.enabled = true
+        junitXml.enabled = true
+    }
+
+    testLogging {
+        events TestLogEvent.SKIPPED, TestLogEvent.FAILED
+
+        exceptionFormat TestExceptionFormat.FULL
+        showExceptions true
+        showCauses true
+        showStackTraces true
+    }
+}
+
+task e2eTest(type: Test) {
+    group "verification"
+
+    useJUnitPlatform {
+        includeTags TAG_E2E_TEST
+        excludeTags "*"
+    }
+
+    reports {
+        html.enabled = true
+        junitXml.enabled = true
+    }
+
+    testLogging {
+        events TestLogEvent.SKIPPED, TestLogEvent.FAILED
 
         exceptionFormat TestExceptionFormat.FULL
         showExceptions true


### PR DESCRIPTION
### 개요
테스트들을 실행 규모별로 그룹화하고, 실행 결과 종합 화면의 내용을 보기 좋게 바꾼다

### AS-IS
테스트가 그룹으로 나뉘어져 있지 않다

### TO-BE
Gradle 의 'test' task 실행시 등록한 테스트들을 모두 실행해 버리기 때문에 로컬에서 간단한 수정을 올릴 때도 매번 모든 테스트 실행완료를 기다려야 해서 불편하다.

따라서 이를 해소하기 위해 테스트를 그룹화하고 개발자 기기에서는 빠른 테스트만 실행할 수 있도록 돕는다.

또한 Gradle 의 test 스크립트의 출력결과가 너무 장황하기 때문에 이를 하나로 합친 스크립트를 추가한다.