### PR TITLE
Feature/hjchang/document history

### DIFF
--- a/app-core/src/main/kotlin/kr/flab/wiki/core/domain/document/DocumentHistory.kt
+++ b/app-core/src/main/kotlin/kr/flab/wiki/core/domain/document/DocumentHistory.kt
@@ -1,6 +1,7 @@
 package kr.flab.wiki.core.domain.document
 
 import kr.flab.wiki.core.common.annotation.DomainModel
+import kr.flab.wiki.core.domain.document.persistence.DocumentHistoryEntity
 import kr.flab.wiki.core.domain.user.User
 import java.time.LocalDateTime
 
@@ -26,4 +27,14 @@ interface DocumentHistory {
     val creator: User
 
     val createdAt: LocalDateTime
+    companion object {
+        fun newInstance(
+            title: String,
+            body: String,
+            creator: User,
+            createdAt: LocalDateTime
+        ): DocumentHistory {
+            return DocumentHistoryEntity(title, body, creator, createdAt)
+        }
+    }
 }

--- a/app-core/src/main/kotlin/kr/flab/wiki/core/domain/document/impl/DocumentContributorServiceImpl.kt
+++ b/app-core/src/main/kotlin/kr/flab/wiki/core/domain/document/impl/DocumentContributorServiceImpl.kt
@@ -1,0 +1,19 @@
+package kr.flab.wiki.core.domain.document.impl
+
+import kr.flab.wiki.core.domain.document.Document
+import kr.flab.wiki.core.domain.document.service.DocumentContributorService
+import kr.flab.wiki.core.domain.document.repository.DocumentRepository
+import kr.flab.wiki.core.domain.user.User
+
+class DocumentContributorServiceImpl(
+    private val documentRepository: DocumentRepository
+) : DocumentContributorService {
+    override fun findDocumentContributor(title: String): List<User> {
+        val documents = documentRepository.findAllHistoryByTitle(title)
+
+        return documents.map { it.creator }
+    }
+    override fun findContributedDocument(user: User): List<Document> {
+        return documentRepository.findDocumentsByUser(user)
+    }
+}

--- a/app-core/src/main/kotlin/kr/flab/wiki/core/domain/document/impl/DocumentHistoryServiceImpl.kt
+++ b/app-core/src/main/kotlin/kr/flab/wiki/core/domain/document/impl/DocumentHistoryServiceImpl.kt
@@ -7,7 +7,7 @@ import kr.flab.wiki.core.domain.document.repository.DocumentRepository
 class DocumentHistoryServiceImpl(
     private val documentRepository: DocumentRepository
 ) : DocumentHistoryService {
-    override fun findDocumentHistory(title: String): MutableList<DocumentHistory> {
+    override fun findDocumentHistory(title: String): List<DocumentHistory> {
         return documentRepository.findAllHistoryByTitle(title)
     }
 }

--- a/app-core/src/main/kotlin/kr/flab/wiki/core/domain/document/repository/DocumentRepository.kt
+++ b/app-core/src/main/kotlin/kr/flab/wiki/core/domain/document/repository/DocumentRepository.kt
@@ -3,6 +3,7 @@ package kr.flab.wiki.core.domain.document.repository
 import kr.flab.wiki.core.common.exception.document.DocumentNotFoundException
 import kr.flab.wiki.core.domain.document.Document
 import kr.flab.wiki.core.domain.document.DocumentHistory
+import kr.flab.wiki.core.domain.user.User
 
 interface DocumentRepository {
     /**
@@ -22,4 +23,8 @@ interface DocumentRepository {
     fun findAllByTitle(title: String): MutableList<Document>
 
     fun findAllHistoryByTitle(title: String): MutableList<DocumentHistory>
+
+    fun findDocumentsByUser(user: User) : List<Document>
+
+
 }

--- a/app-core/src/main/kotlin/kr/flab/wiki/core/domain/document/repository/DocumentRepository.kt
+++ b/app-core/src/main/kotlin/kr/flab/wiki/core/domain/document/repository/DocumentRepository.kt
@@ -22,9 +22,7 @@ interface DocumentRepository {
 
     fun findAllByTitle(title: String): MutableList<Document>
 
-    fun findAllHistoryByTitle(title: String): MutableList<DocumentHistory>
+    fun findAllHistoryByTitle(title: String): List<DocumentHistory>
 
-    fun findDocumentsByUser(user: User) : List<Document>
-
-
+    fun findDocumentsByUser(user: User): List<Document>
 }

--- a/app-core/src/main/kotlin/kr/flab/wiki/core/domain/document/service/DocumentContributorService.kt
+++ b/app-core/src/main/kotlin/kr/flab/wiki/core/domain/document/service/DocumentContributorService.kt
@@ -1,0 +1,20 @@
+package kr.flab.wiki.core.domain.document.service
+
+import kr.flab.wiki.core.common.annotation.DomainService
+import kr.flab.wiki.core.domain.document.Document
+import kr.flab.wiki.core.domain.document.impl.DocumentContributorServiceImpl
+import kr.flab.wiki.core.domain.document.repository.DocumentRepository
+import kr.flab.wiki.core.domain.user.User
+
+@DomainService
+interface DocumentContributorService {
+    fun findDocumentContributor(title: String): List<User>
+    fun findContributedDocument(user: User): List<Document>
+    companion object {
+        fun newInstance(
+            documentRepository: DocumentRepository,
+        ): DocumentContributorService {
+            return DocumentContributorServiceImpl(documentRepository)
+        }
+    }
+}

--- a/app-core/src/main/kotlin/kr/flab/wiki/core/domain/document/service/DocumentHistoryService.kt
+++ b/app-core/src/main/kotlin/kr/flab/wiki/core/domain/document/service/DocumentHistoryService.kt
@@ -7,7 +7,7 @@ import kr.flab.wiki.core.domain.document.repository.DocumentRepository
 
 @DomainService
 interface DocumentHistoryService {
-    fun findDocumentHistory(title: String): MutableList<DocumentHistory>
+    fun findDocumentHistory(title: String): List<DocumentHistory>
 
     companion object {
         fun newInstance(


### PR DESCRIPTION
1. 문서 기여자 서비스 DocumentContributionService 추가
2. 문서 title로 기여자 목록 조회
3. user가 기여한 문서 리스트 조회

기능을 추가했습니다. 2번의 경우 문사 역사 조회 기능과 겹치는 부분이라 생략이 가능하다고 생각됩니다.
3번의 기능을 구현하기 위해서 user관련 정보를 문서에 저장해야합니다.
그러나 현재는 어떤 값을 user의 키값으로 지정할지 정하지 않아 임시로 이메일 주소를 문서 기여자의 id값으로 사용했습니다.

테스트의 경우 먼저 문서 생성/수정이 발생해야하므로 다른 서비스의 기능이 선행되야하는 문제가 있습니다.
이 경우 별도의 테스트파일을 만드는 것이 좋을지, 기존의 테스트 시나리오에 추가하는 것이 좋을지 애매한 부분이 있어 보류해두었습니다ㅠ


